### PR TITLE
feat: add zero-argument defaults and English docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+*.log
+*.tmp
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,117 @@
+# vm-pcloud-sync
+
+VM ⇄ pCloud sync via **rclone** (`copy`/`sync`/`bisync`).  
+Single-file Python wrapper with **built-in exclude rules** and CLI options for extra includes/excludes.
+
+> **Zero-argument default:**  
+> Just run `python3 vm_pcloud_sync.py`  
+> = `--src ~/TradingHub --dest pcloud:TradingHub --mode sync`
+
+## Features
+- `copy` / `sync` (one-way) and `bisync` (two-way)
+- Built-in excludes: `.git/`, `.venv/`, `__pycache__/`, `*.pyc` …  
+  (disable via `--no-default-excludes`; extend with `--exclude/--include`)
+- `--resync` for the **first** bisync run (baseline)
+- Optional `--snapshot` (for copy/sync) to write into a timestamped subfolder
+- Works well with **systemd user timers** on Linux VMs
+- Verbosity control (`-v/-vv/-vvv`), `--fast-list`, `--dry-run`
+
+## Prerequisites
+- Linux VM (e.g., Ubuntu/Debian)
+- rclone ≥ 1.62  
+  ```bash
+  sudo apt-get update && sudo apt-get install -y rclone
+  rclone version
+  ```
+- A configured pCloud remote (assumed name: `pcloud:`)
+  ```bash
+  rclone config
+  rclone about pcloud:
+  ```
+
+## Quick Start
+
+### 0) Zero-argument default
+```bash
+python3 vm_pcloud_sync.py
+# == --src ~/TradingHub --dest pcloud:TradingHub --mode sync
+```
+
+### 1) One-way backup (copy)
+```bash
+python3 vm_pcloud_sync.py --src ~/TradingHub --dest pcloud:TradingHub --mode copy
+```
+
+### 2) One-way mirror (sync)
+```bash
+python3 vm_pcloud_sync.py --src ~/TradingHub --dest pcloud:TradingHub --mode sync -n   # dry-run
+python3 vm_pcloud_sync.py --src ~/TradingHub --dest pcloud:TradingHub --mode sync
+```
+
+### 3) Two-way sync (bisync)
+**First run (baseline):**
+```bash
+python3 vm_pcloud_sync.py --src ~/TradingHub --dest pcloud:TradingHub --mode bisync --resync
+```
+**Daily run:**
+```bash
+python3 vm_pcloud_sync.py --src ~/TradingHub --dest pcloud:TradingHub --mode bisync
+```
+**Add your own rules:**
+```bash
+python3 vm_pcloud_sync.py --mode bisync \
+  --src ~/TradingHub --dest pcloud:TradingHub \
+  --exclude "/**/logs/**" --include "/**/*.csv"
+```
+
+## CLI summary
+* `--src ...` (multi) | `--dest ...` (remote:path) | `--mode copy|sync|bisync`
+* `--dry-run` | `--fast` | `-v/-vv/-vvv`
+* `--no-default-excludes` | `--exclude PATTERN` | `--include PATTERN`
+* `--snapshot` (copy/sync only) | `--name SUBDIR`
+* `--resync` (bisync only) | `--conflict-resolve newer|older|path1|path2|larger|smaller`
+
+## Systemd (optional)
+Create user service & timer for periodic bisync (edit paths as needed).
+
+`~/.config/systemd/user/vm-pcloud-sync.service`
+```ini
+[Unit]
+Description=VM <-> pCloud sync (bisync)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 /home/<USER>/vm_pcloud_sync.py \
+  --mode bisync --src /home/<USER>/TradingHub --dest pcloud:TradingHub
+```
+
+`~/.config/systemd/user/vm-pcloud-sync.timer`
+```ini
+[Unit]
+Description=Run vm-pcloud-sync every 15 minutes
+
+[Timer]
+OnBootSec=2m
+OnUnitActiveSec=15m
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable:
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now vm-pcloud-sync.timer
+```
+
+## Notes
+* Use `--resync` **once** on the first `bisync` to establish the baseline.
+* If multiple machines sync the same path, **stagger** their timers to avoid concurrent operations.
+* Built-in excludes can be disabled with `--no-default-excludes`.
+
+## License
+MIT
+

--- a/vm_pcloud_sync.py
+++ b/vm_pcloud_sync.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-vm_pcloud_sync.py
-VM ↔ pCloud 同步小工具（呼叫 rclone），支援：
-- --mode copy | sync | bisync
-- 內建排除規則，可用 --exclude/--include 附加；可用 --no-default-excludes 關閉內建
-- --snapshot（只用於 copy/sync）：目的端加時間戳子目錄
-- --resync（只用於 bisync 首次建立基準）
-- --dry-run, --fast（--fast-list）, --conflict-resolve（bisync）
+VM ↔ pCloud sync helper wrapping **rclone**.
+
+Features
+--------
+- ``--mode copy | sync | bisync``
+- Built-in exclude rules (``--no-default-excludes`` to disable) and
+  ``--exclude/--include`` for extra patterns
+- ``--snapshot`` (copy/sync only) writes to a timestamped subfolder
+- ``--resync`` for the first bisync run to create the baseline
+- ``--dry-run``, ``--fast`` (``--fast-list``) and ``--conflict-resolve``
+
+Zero-argument defaults:
+``--src ~/TradingHub --dest pcloud:TradingHub --mode sync``
 """
 
 import argparse
@@ -17,6 +23,9 @@ import subprocess
 import sys
 from pathlib import Path
 from datetime import datetime
+
+DEFAULT_SRC = str(Path.home() / "TradingHub")
+DEFAULT_DEST = "pcloud:TradingHub"
 
 DEFAULT_EXCLUDES = [
     "/**/.git/**",
@@ -32,12 +41,12 @@ DEFAULT_EXCLUDES = [
 def which_or_die(exe: str) -> str:
     path = shutil.which(exe)
     if not path:
-        print(f"❌ 找不到 {exe}，請先安裝（例：sudo apt-get install rclone）", file=sys.stderr)
+        print(f"❌ could not find {exe}; please install it (e.g. sudo apt-get install rclone)", file=sys.stderr)
         sys.exit(2)
     return path
 
 def remote_name_from_dest(dest: str) -> str | None:
-    # e.g. "pcloud:TradingHub" -> "pcloud"
+    """Extract remote name from ``remote:path`` style strings."""
     if ":" in dest:
         return dest.split(":", 1)[0]
     return None
@@ -60,28 +69,28 @@ def build_exclude_args(default_on: bool, extra_excludes: list[str], extra_includ
     return args
 
 def main():
-    ap = argparse.ArgumentParser(description="VM ↔ pCloud 同步工具（rclone 包裝）")
-    ap.add_argument("--src", nargs="+", required=True, help="來源資料夾（可多個）")
-    ap.add_argument("--dest", required=True, help="目的端（例如 pcloud:TradingHub）")
-    ap.add_argument("--mode", choices=["copy", "sync", "bisync"], default="copy", help="copy/sync 單向，bisync 雙向")
-    ap.add_argument("--name", default=None, help="目的端固定子目錄名稱（預設用來源資料夾名）")
-    ap.add_argument("--snapshot", action="store_true", help="copy/sync 時在目的端加時間戳子目錄（bisync 不適用）")
-    ap.add_argument("--dry-run", action="store_true", help="試跑（不真的改動）")
-    ap.add_argument("--fast", action="store_true", help="啟用 --fast-list")
-    ap.add_argument("--verbose", "-v", action="count", default=1, help="提高輸出詳盡度，可重複，例如 -vv")
-    ap.add_argument("--no-default-excludes", action="store_true", help="不要使用內建排除規則")
-    ap.add_argument("--exclude", action="append", default=[], help="附加自訂排除規則（可重複）")
-    ap.add_argument("--include", action="append", default=[], help="附加自訂包含規則（可重複）")
-    # bisync 專用
-    ap.add_argument("--resync", action="store_true", help="bisync 首次建立基準（只在第一次執行使用）")
+    ap = argparse.ArgumentParser(description="VM ↔ pCloud sync helper (rclone wrapper)")
+    ap.add_argument("--src", nargs="+", default=[DEFAULT_SRC], help=f"Source directories (default: {DEFAULT_SRC})")
+    ap.add_argument("--dest", default=DEFAULT_DEST, help=f"Destination (default: {DEFAULT_DEST})")
+    ap.add_argument("--mode", choices=["copy", "sync", "bisync"], default="sync", help="copy/sync one-way, bisync two-way")
+    ap.add_argument("--name", default=None, help="Fixed subdirectory name at destination (defaults to source name)")
+    ap.add_argument("--snapshot", action="store_true", help="For copy/sync: append timestamped subdir at destination")
+    ap.add_argument("--dry-run", action="store_true", help="Dry run")
+    ap.add_argument("--fast", action="store_true", help="Enable --fast-list")
+    ap.add_argument("--verbose", "-v", action="count", default=1, help="Increase verbosity; repeat for more output")
+    ap.add_argument("--no-default-excludes", action="store_true", help="Disable built-in exclude rules")
+    ap.add_argument("--exclude", action="append", default=[], help="Additional exclude patterns (can repeat)")
+    ap.add_argument("--include", action="append", default=[], help="Additional include patterns (can repeat)")
+    # bisync-specific
+    ap.add_argument("--resync", action="store_true", help="First run baseline for bisync")
     ap.add_argument("--conflict-resolve", default="newer",
                     choices=["none","newer","older","path1","path2","larger","smaller"],
-                    help="bisync 衝突處理策略（預設 newer）")
+                    help="Conflict resolution strategy (bisync)")
     args = ap.parse_args()
 
     rclone = which_or_die("rclone")
 
-    # 快速檢查 remote 可用
+    # quick check that remote is reachable
     remote = remote_name_from_dest(args.dest)
     if remote:
         run([rclone, "about", f"{remote}:"])
@@ -97,10 +106,10 @@ def main():
     for s in args.src:
         src = Path(os.path.expanduser(s)).resolve()
         if not src.exists() or not src.is_dir():
-            print(f"❌ 來源不存在或不是目錄：{src}", file=sys.stderr)
+            print(f"❌ source missing or not a directory: {src}", file=sys.stderr)
             continue
 
-        # 組目的端路徑
+        # destination path
         base = args.name if args.name else src.name
         dest_path = args.dest.rstrip("/")
         if args.mode in ("copy", "sync"):
@@ -108,10 +117,10 @@ def main():
                 dest_path = f"{dest_path}/{base}-{ts}"
             else:
                 dest_path = f"{dest_path}/{base}"
-        else:  # bisync：目的端不做 snapshot，rclone 自己管理
+        else:  # bisync manages timestamps itself
             dest_path = f"{dest_path}/{base}"
 
-        # 組排除/包含
+        # excludes/includes
         fx = build_exclude_args(not args.no_default_excludes, args.exclude, args.include)
 
         if args.mode in ("copy", "sync"):
@@ -126,14 +135,14 @@ def main():
                 "--conflict-resolve", args.conflict_resolve,
             ]
             if args.resync:
-                cmd.insert(2, "--resync")  # 放在 'bisync' 後面的位置也可
+                cmd.insert(2, "--resync")
 
-        print(f"\n=== {args.mode.upper()} ===\n來源：{src}\n目的：{dest_path}\n")
+        print(f"\n=== {args.mode.upper()} ===\nsource: {src}\ndestination: {dest_path}\n")
         rc = run(cmd)
         if rc == 0:
-            print(f"✅ 完成：{src} → {dest_path}\n")
+            print(f"✅ done: {src} → {dest_path}\n")
         else:
-            print(f"❌ 失敗（返回碼 {rc}）：{src} → {dest_path}\n", file=sys.stderr)
+            print(f"❌ failed (exit {rc}): {src} → {dest_path}\n", file=sys.stderr)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace README with English quick-start and systemd instructions
- allow running `vm_pcloud_sync.py` with no arguments using default src/dest and sync mode

## Testing
- `python -m py_compile vm_pcloud_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae77049ecc83228324d7cac22c5dd3