### PR TITLE
Add reverse pCloud sync option and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,27 @@ python3 vm_pcloud_sync.py
 # == --src ~/TradingHub --dest pcloud:TradingHub --mode sync
 ```
 
-### 1) One-way backup (copy)
+### 1) Reverse (pull from pCloud)
+
+```bash
+python3 vm_pcloud_sync.py --reverse
+# == rclone sync pcloud:TradingHub ~/TradingHub
+```
+
+### 2) One-way backup (copy)
 
 ```bash
 python3 vm_pcloud_sync.py --src ~/TradingHub --dest pcloud:TradingHub --mode copy
 ```
 
-### 2) One-way mirror (sync)
+### 3) One-way mirror (sync)
 
 ```bash
 python3 vm_pcloud_sync.py --src ~/TradingHub --dest pcloud:TradingHub --mode sync -n   # dry-run
 python3 vm_pcloud_sync.py --src ~/TradingHub --dest pcloud:TradingHub --mode sync
 ```
 
-### 3) Two-way sync (bisync)
+### 4) Two-way sync (bisync)
 
 **First run (baseline):**
 
@@ -81,6 +88,7 @@ python3 vm_pcloud_sync.py --mode bisync \
 * `--no-default-excludes` | `--exclude PATTERN` | `--include PATTERN`
 * `--snapshot` (copy/sync only) | `--name SUBDIR`
 * `--resync` (bisync only) | `--conflict-resolve newer|older|path1|path2|larger|smaller`
+* `--reverse`/`--pull` (flip direction: remote → local)
 
 ## Systemd (optional)
 


### PR DESCRIPTION
## Summary
- Support `--reverse`/`--pull` to flip sync direction from pCloud to VM
- Document reverse usage in Quick Start and CLI summary

## Testing
- `python3 -m py_compile vm_pcloud_sync.py`
- `python3 vm_pcloud_sync.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68ae7e8724a88322b04a3b8f17d5b5e5