### PR TITLE
Change default mode to copy

### DIFF
--- a/vm_pcloud_sync.py
+++ b/vm_pcloud_sync.py
@@ -3,7 +3,7 @@
 """
 vm_pcloud_sync.py
 Default run (no args):
-  src=~/TradingHub  dest=pcloud:TradingHub  mode=sync  (direction: local -> remote)
+  src=~/TradingHub  dest=pcloud:TradingHub  mode=copy  (direction: local -> remote)
 
 Options:
   --src ... (multi)      --dest ...        --mode copy|sync|bisync
@@ -69,8 +69,8 @@ def main():
                     help="Source directory(ies). Default: ~/TradingHub")
     ap.add_argument("--dest", default="pcloud:TradingHub",
                     help="Destination (remote:path). Default: pcloud:TradingHub")
-    ap.add_argument("--mode", choices=["copy", "sync", "bisync"], default="sync",
-                    help="Default: sync")
+    ap.add_argument("--mode", choices=["copy", "sync", "bisync"], default="copy",
+                    help="Default: copy")
     ap.add_argument("--reverse", "--pull", dest="reverse", action="store_true",
                     help="Flip direction: remote -> local (pcloud -> VM).")
     ap.add_argument("--name", default=None,


### PR DESCRIPTION
## Summary
- default mode is now `copy` instead of `sync`
- update command-line help text and docstring for new default

## Testing
- `python3 vm_pcloud_sync.py --dry-run -vv` *(fails: rclone not found)*
- `python3 vm_pcloud_sync.py --reverse --dry-run -vv` *(fails: rclone not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae80953e8c83229e921ffdcc29ad96